### PR TITLE
Fix: Added symfony http-foundation as requirement

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -17,7 +17,8 @@
     ],
     "require": {
         "php": "^7.0",
-        "rareloop/router": "^1.0.0"
+        "rareloop/router": "^1.0.0",
+        "symfony/http-foundation": "^4.0.0"
     },
     "require-dev": {
         "brain/monkey": "^2.0.2",


### PR DESCRIPTION
To fix the exception below I'm adding it as requirement

Fatal error: Uncaught Error: Class 'Symfony\Component\HttpFoundation\Request' not found in /var/www/ab-wp/htdocs/public/web/app/plugins/wp-router/src/Router.php:53 Stack trace: #0 /var/www/ab-wp/htdocs/public/web/wp/wp-includes/class-wp-hook.php(286): Rareloop\WordPress\Router\Router::processRequest('') #1 /var/www/ab-wp/htdocs/public/web/wp/wp-includes/class-wp-hook.php(310): WP_Hook->apply_filters(NULL, Array) #2 /var/www/ab-wp/htdocs/public/web/wp/wp-includes/plugin.php(453): WP_Hook->do_action(Array) #3 /var/www/ab-wp/htdocs/public/web/wp/wp-settings.php(471): do_action('wp_loaded') #4 /var/www/ab-wp/htdocs/public/web/wp-config.php(9): require_once('/var/www/ab-wp/...') #5 /var/www/ab-wp/htdocs/public/web/wp/wp-load.php(42): require_once('/var/www/ab-wp/...') #6 /var/www/ab-wp/htdocs/public/web/wp/wp-blog-header.php(13): require_once('/var/www/ab-wp/...') #7 /var/www/ab-wp/htdocs/public/web/index.php(5): require('/var/www/ab-wp/...') #8 {main} thrown in /var/www/ab-wp/htdocs/public/web/app/plugins/wp-router/src/Router.php on line 53